### PR TITLE
Remove unused IDisposable array

### DIFF
--- a/src/htmlMode.ts
+++ b/src/htmlMode.ts
@@ -11,14 +11,10 @@ import * as languageFeatures from './languageFeatures';
 
 import Promise = monaco.Promise;
 import Uri = monaco.Uri;
-import IDisposable = monaco.IDisposable;
 
 export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
 
-	let disposables: IDisposable[] = [];
-
 	const client = new WorkerManager(defaults);
-	disposables.push(client);
 
 	const worker: languageFeatures.WorkerAccessor = (...uris: Uri[]): Promise<HTMLWorker> => {
 		return client.getLanguageServiceWorker(...uris);
@@ -27,14 +23,14 @@ export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
 	let languageId = defaults.languageId;
 
 	// all modes
-	disposables.push(monaco.languages.registerCompletionItemProvider(languageId, new languageFeatures.CompletionAdapter(worker)));
-	disposables.push(monaco.languages.registerDocumentHighlightProvider(languageId, new languageFeatures.DocumentHighlightAdapter(worker)));
-	disposables.push(monaco.languages.registerLinkProvider(languageId, new languageFeatures.DocumentLinkAdapter(worker)));
+	monaco.languages.registerCompletionItemProvider(languageId, new languageFeatures.CompletionAdapter(worker));
+	monaco.languages.registerDocumentHighlightProvider(languageId, new languageFeatures.DocumentHighlightAdapter(worker));
+	monaco.languages.registerLinkProvider(languageId, new languageFeatures.DocumentLinkAdapter(worker));
 
 	// only html
 	if (languageId === 'html') {
-		disposables.push(monaco.languages.registerDocumentFormattingEditProvider(languageId, new languageFeatures.DocumentFormattingEditProvider(worker)));
-		disposables.push(monaco.languages.registerDocumentRangeFormattingEditProvider(languageId, new languageFeatures.DocumentRangeFormattingEditProvider(worker)));
-		disposables.push(new languageFeatures.DiagnostcsAdapter(languageId, worker));
+		monaco.languages.registerDocumentFormattingEditProvider(languageId, new languageFeatures.DocumentFormattingEditProvider(worker));
+		monaco.languages.registerDocumentRangeFormattingEditProvider(languageId, new languageFeatures.DocumentRangeFormattingEditProvider(worker));
+		new languageFeatures.DiagnostcsAdapter(languageId, worker);
 	}
 }


### PR DESCRIPTION
There is a `IDisposable[]` that gets created in `htmlMode.ts` but it doesn't seem to serve any purpose. It should be removed instead.

See Microsoft/monaco-editor#738.