### PR TITLE
fix(workerManager.js) : Added a check for the existence of the worker

### DIFF
--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -80,7 +80,9 @@ export class WorkerManager {
 				_client = client;
 			})
 			.then((_) => {
-				return this._worker.withSyncedResources(resources);
+				if (this._worker) {
+					return this._worker.withSyncedResources(resources);
+				}
 			})
 			.then((_) => _client);
 	}


### PR DESCRIPTION
### Description about the issue 
monaco-editor-version : 0.25.2
OS : Mac OS
Browser : Chrome

In my application there are 2 instances of monaco editor and when I create the second instance it was throwing this kind of error ( I'm not sure about the proper origin of this issue )

<img width="1182" alt="Screen Shot 2021-07-16 at 2 00 40 PM" src="https://user-images.githubusercontent.com/29809906/125917886-fe5b2f8d-6728-4c6b-8ceb-c3005ade1ce1.png">

Upon checking in I found a similar issue https://github.com/microsoft/monaco-editor/issues/1254
I found a similar check in monaco-typescript https://github.com/microsoft/monaco-typescript/commit/e4ab9e4360fc8cd559a6550f329340986fb00135#diff-871939a01a574ea561538fe0d1a0d69d238662de6f7bd102d3a1b2a1212f7a5bR120

So I have added a similar check to monaco-html 